### PR TITLE
feat(npm): fail request if 'node_modules' exists

### DIFF
--- a/cachi2/core/package_managers/npm.py
+++ b/cachi2/core/package_managers/npm.py
@@ -558,6 +558,13 @@ def _resolve_npm(pkg_path: RootedPath) -> ResolvedNpmPackage:
             solution="Please double-check that you have specified the correct path to the package directory containing one of those two files",
         )
 
+    node_modules_path = pkg_path.join_within_root("node_modules")
+    if node_modules_path.path.exists():
+        raise PackageRejected(
+            "The 'node_modules' directory cannot be present in the source repository",
+            solution="Ensure that there are no 'node_modules' directories in your repo",
+        )
+
     package_lock = PackageLock.from_file(package_lock_path)
 
     return {

--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -150,9 +150,9 @@ black==23.7.0 \
     --hash=sha256:f9062af71c59c004cd519e2fb8f5d25d39e46d3af011b41ab43b9c74e27e236f \
     --hash=sha256:fb074d8b213749fa1d077d630db0d5f8cc3b2ae63587ad4116e8a436e9bbe995
     # via cachi2 (pyproject.toml)
-certifi==2023.5.7 \
-    --hash=sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7 \
-    --hash=sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716
+certifi==2023.7.22 \
+    --hash=sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082 \
+    --hash=sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9
     # via requests
 charset-normalizer==3.2.0 \
     --hash=sha256:04e57ab9fbf9607b77f7d057974694b4f6b142da9ed4a199859d9d4d5c63fe96 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -119,9 +119,9 @@ beautifulsoup4==4.12.2 \
     --hash=sha256:492bbc69dca35d12daac71c4db1bfff0c876c00ef4a2ffacce226d4638eb72da \
     --hash=sha256:bd2520ca0d9d7d12694a53d44ac482d181b4ec1888909b035a3dbf40d0f57d4a
     # via cachi2 (pyproject.toml)
-certifi==2023.5.7 \
-    --hash=sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7 \
-    --hash=sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716
+certifi==2023.7.22 \
+    --hash=sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082 \
+    --hash=sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9
     # via requests
 charset-normalizer==3.2.0 \
     --hash=sha256:04e57ab9fbf9607b77f7d057974694b4f6b142da9ed4a199859d9d4d5c63fe96 \


### PR DESCRIPTION
- https://issues.redhat.com/browse/STONEBLD-1474

Committing node_modules into the repository would allow the user to "vendor" their dependencies, in a way.

The RHTAP build would have no guarantee that the build really used the dependencies that cachi2 prefetched.

The generated SBOM could be inaccurate.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)
